### PR TITLE
Add Scarf-js for anonymized installation analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ In the project directory, you can run:
 
 To install dependencies.
 
+Meet uses [scarf-js](https://github.com/scarf-sh/scarf.js) to collect anonymized installation analytics. These analytics help support the maintainers of this package. However, if you'd like to opt out, you can do so by setting `scarfSettings.enabled = false` in your project's package.json, or by setting the environment variable `SCARF_ANALYTICS=false` before you install. See the scarf-js readme for more information.
+
 ### `npm start`
 
 Runs the app in the development mode.<br />

--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,6 +1285,11 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@scarf/scarf": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz",
+      "integrity": "sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ=="
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@scarf/scarf": "^1.0.5",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",


### PR DESCRIPTION
This change adds a dependency on scarf-js for installation analytics to support the maintainers of this project.

Discussion from everyone is welcome! Some background on the library and the problem it's solving can be found in this post here: https://github.com/scarf-sh/scarf-js/blob/master/WHY.org. The package README (https://github.com/scarf-sh/scarf-js) has more info on exactly what data is sent on each install and how users can opt-out if they choose.